### PR TITLE
Add StrInt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+parse

--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -1,0 +1,31 @@
+class ConstructBase:
+    def __init__(self, format_, name=None):
+        self._format = f"{{:{format_}}}"
+        self._name = name
+
+    def __div(self, other):
+        if not isinstance(other, str):
+            raise TypeError("Division is support only for strings")
+        return ConstructBase(self._format, other)
+
+    def __truediv__(self, other):
+        return self.__div(other)
+
+    def __rtruediv__(self, other):
+        return self.__div(other)
+
+    def _build(self, value):
+        raise NotImplementedError("Should be overridden by the child classes")
+
+    def _parse(self, string):
+        raise NotImplementedError("Should be overridden by the child classes")
+
+    def build(self, value):
+        return self._build(value)
+
+    def parse(self, string):
+        return self._parse(string)
+
+if __name__ == "__main__":
+    m = ConstructBase("")
+    m / "my_name"

--- a/src/str_construct_exceptions.py
+++ b/src/str_construct_exceptions.py
@@ -1,0 +1,14 @@
+
+class StrConstructError(ValueError):
+    """_summary_
+
+    Args:
+        ValueError (_type_): _description_
+    """
+
+class StrConstructMismatchingFormatError(StrConstructError):
+    """_summary_
+
+    Args:
+        StrConstructError (_type_): _description_
+    """

--- a/src/str_int.py
+++ b/src/str_int.py
@@ -1,0 +1,13 @@
+from parse import parse
+
+from construct_base import ConstructBase
+
+class StrInt(ConstructBase):
+    def _build(self, value):
+        return f"{self._format}".format(value)
+
+    def _parse(self, string):
+        format_= self._format
+        if format_ == "{:}":
+            format_ = "{:d}"
+        return parse(f"{format_}", string, case_sensitive=True)[0]

--- a/test/unit/pytest.ini
+++ b/test/unit/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test_*.py
+python_classes = Test*
+python_functions = test*

--- a/test/unit/test_str_int.py
+++ b/test/unit/test_str_int.py
@@ -1,0 +1,40 @@
+import sys
+import os
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
+
+from str_int import StrInt
+from str_construct_exceptions import StrConstructMismatchingFormatError
+
+class TestStrInt:
+    def test_build_positive(self):
+        assert StrInt("").build(2) == "2"
+
+    def test_parse_positive(self):
+        assert StrInt("").parse("2") == 2
+
+    def test_build_negative(self):
+        assert StrInt("").build(-2) == "-2"
+
+    def test_parse_negative(self):
+        assert StrInt("").parse("-2") == -2
+
+    def test_build_hex_lower_case(self):
+        assert StrInt("x").build(15) == "f"
+
+    def test_parse_hex_lower_case(self):
+        assert StrInt("x").parse("f") == 15
+
+    @pytest.mark.xfail()
+    def test_parse_hex_lower_case_raises_error(self):
+        with pytest.raises(StrConstructMismatchingFormatError):
+            StrInt("x").parse("F")
+
+    def test_build_hex_padding(self):
+        assert StrInt("03X").build(10) == "00A"
+
+    @pytest.mark.xfail()
+    def test_parse_hex_padding(self):
+        assert StrInt("03X").parse("00A") == 10


### PR DESCRIPTION
A simple class (and a base class which will be required by all Str Construct objects) to handle build and parse. Currently, the parsing uses the Parse package (https://pypi.org/project/parse/). But it appears to have some problems when compared to the formats supported by the `format` method. The corresponding test cases are marked with xfail.

Also, added the minimal set of files to run unit tests by pytest.