### PR TITLE
Add StrStruct

### DIFF
--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -1,18 +1,21 @@
 class ConstructBase:
-    def __init__(self, format_, name=None):
-        self._format = f"{{:{format_}}}"
-        self._name = name
+    def __init__(self, format_, name=None, format_processed=False):
+        if format_processed is False:
+            self._format = f"{{:{format_}}}"
+        else:
+            self._format = format_
+        self.name = name
 
-    def __div(self, other):
+    def _div(self, other):
         if not isinstance(other, str):
             raise TypeError("Division is support only for strings")
-        return ConstructBase(self._format, other)
+        return self.__class__(self._format, other, format_processed=True)
 
     def __truediv__(self, other):
-        return self.__div(other)
+        return self._div(other)
 
     def __rtruediv__(self, other):
-        return self.__div(other)
+        return self._div(other)
 
     def _build(self, value):
         raise NotImplementedError("Should be overridden by the child classes")

--- a/src/str_construct_exceptions.py
+++ b/src/str_construct_exceptions.py
@@ -13,7 +13,14 @@ class StrConstructMismatchingFormatError(StrConstructError):
         StrConstructError (_type_): _description_
     """
 
-class StrConstructParsingError(StrConstructError):
+class StrConstructParseError(StrConstructError):
+    """_summary_
+
+    Args:
+        StrConstructError (_type_): _description_
+    """
+
+class StrConstructBuildError(StrConstructError):
     """_summary_
 
     Args:

--- a/src/str_float.py
+++ b/src/str_float.py
@@ -1,7 +1,7 @@
 from parse import parse
 
 from construct_base import ConstructBase
-from str_construct_exceptions import StrConstructParsingError
+from str_construct_exceptions import StrConstructParseError
 
 class StrFloat(ConstructBase):
     def _build(self, value):
@@ -17,5 +17,5 @@ class StrFloat(ConstructBase):
         format_ = format_.replace("f}", "g}")
         parsed = parse(f"{format_}", string, case_sensitive=True)
         if parsed is None:
-            raise StrConstructParsingError(f"Could not parse \"{string}\" with format {self._format}")
+            raise StrConstructParseError(f"Could not parse \"{string}\" with format {self._format}")
         return parsed[0]

--- a/src/str_struct.py
+++ b/src/str_struct.py
@@ -1,0 +1,57 @@
+
+from construct_base import ConstructBase
+from str_construct_exceptions import StrConstructBuildError, StrConstructParseError
+
+class StrStruct(ConstructBase):
+    def __init__(self, *args, **kwargs):
+        for item in args:
+            if not isinstance(item, ConstructBase):
+                raise TypeError(
+                    "All items need to be of type ConstructBase (e.g. StrFloat, StrInt, etc.). Found "
+                    f"a {type(item)}."
+                )
+        self._separator = kwargs["separator"]
+        self.name = kwargs["name"] if "name" in kwargs.keys() else None
+        self._fields = args
+
+    def _div(self, other):
+        # As this class has a different footprint for the __init__ method, we need to
+        # override this method
+        if not isinstance(other, str):
+            raise TypeError("Division is support only for strings")
+        return StrStruct(name=other, separator=self._separator, *self._fields)
+
+    def _build(self, values):
+        if not isinstance(values, dict):
+            raise TypeError("The value for building an StrConstruct should be a dict")
+
+        outputs = []
+        for field in self._fields:
+            if field.name is None:
+                # Well there is no name. So we can't find a given value. In this case, the
+                # build method of the corresponding object is expected to be able to build
+                # without a give value. Let's give it a try.
+                try:
+                    output = field.build()
+                except Exception as e:
+                    raise StrConstructBuildError("Could not build the nameless field")
+
+            else:
+                value = values[field.name]
+                output = field.build(value)
+            outputs.append(output)
+
+        return self._separator.join(outputs)
+
+    def _parse(self, string):
+        values = string.split(self._separator)
+
+        if len(values) != len(self._fields):
+            # What if the separator is also present in a constant field?
+            raise StrConstructParseError("Bad input")
+
+        output = {}
+        for field, value in zip(self._fields, values):
+            output[field.name] = field.parse(value)
+
+        return output

--- a/test/unit/test_str_struct.py
+++ b/test/unit/test_str_struct.py
@@ -1,0 +1,146 @@
+import sys
+import os
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
+
+from str_int import StrInt
+from str_float import StrFloat
+from str_struct import StrStruct
+
+class TestStrStruct:
+    def test_field_type(self):
+        with pytest.raises(TypeError):
+            StrStruct("")
+
+        StrStruct(
+            "field1" / StrInt(""),
+            separator=",",
+        )
+
+    def test_build_type(self):
+        packet = StrStruct(
+            "field1" / StrInt(""),
+            separator=",",
+        )
+        with pytest.raises(TypeError):
+            packet.build(2)
+
+    def test_build_simple(self):
+        packet = StrStruct(
+            "field1" / StrInt(""),
+            "field2" / StrInt("02X"),
+            "field3" / StrFloat(".2f"),
+            separator=",",
+        )
+        output = packet.build(
+            {
+                "field1": 2,
+                "field2": 15,
+                "field3": 3.1,
+
+            }
+        )
+        assert output == "2,0F,3.10"
+
+    def test_build_empty(self):
+        packet = StrStruct(
+            separator=",",
+        )
+        output = packet.build({})
+        assert output == ""
+
+
+    @pytest.mark.xfail(
+        reason="Needs StrConstruct objects that can build without values e.g. StrDefault"
+    )
+    def test_build_with_nameless_fields(self):
+        packet = StrStruct(
+            StrInt(""),
+            "field2" / StrInt("02X"),
+            separator=",",
+        )
+        output = packet.build(
+            {
+                "field2": 15,
+            }
+        )
+        assert output == ""  # ?
+
+    def test_parse_simple(self):
+        packet = StrStruct(
+            "field1" / StrInt(""),
+            "field2" / StrInt("02x"),
+            "field3" / StrFloat(".2f"),
+            separator=",",
+        )
+        output = packet.parse("2,0f,3.10")
+        assert output == {
+                "field1": 2,
+                "field2": 15,
+                "field3": 3.1,
+
+            }
+
+    @pytest.mark.xfail(
+        reason="Needs StrConstruct objects that can build without values e.g. StrDefault"
+    )
+    def test_parse_with_nameless_fields(self):
+        packet = StrStruct(
+            StrInt(""),
+            "field2" / StrInt("02X"),
+            separator=",",
+        )
+        output = packet.parse()
+        assert output == ""  # ?
+
+    def test_build_nested(self):
+        packet = StrStruct(
+            "field1" / StrInt(""),
+            "field2" / StrInt("02X"),
+            "field3" / StrStruct(
+                "field4" / StrFloat(".2f"),
+                separator=",",
+            ),
+            separator=",",
+        )
+        output = packet.build(
+            {
+                "field1": 2,
+                "field2": 15,
+                "field3": {
+                    "field4": 3.1,
+                }
+
+            }
+        )
+        assert output == "2,0F,3.10"
+
+        packet = StrStruct(
+            "field1" / StrInt(""),
+            "field2" / StrInt("02X"),
+            "field3" / StrStruct(
+                "field4" / StrFloat(".2f"),
+                "field5" / StrStruct(
+                    "field6" / StrFloat("03X"),
+                    separator=",",
+                ),
+                separator=",",
+            ),
+            separator=",",
+        )
+        output = packet.build(
+            {
+                "field1": 2,
+                "field2": 15,
+                "field3": {
+                    "field4": 3.1,
+                    "field5": {
+                        "field6": 10,
+                    }
+                }
+
+            }
+        )
+        assert output == "2,0F,3.10,00A"


### PR DESCRIPTION
Adding the basics of StrStruct. StrStruct is basically a list of other StrConstruct objects (including StrStruct itself) that can be built when the parent StrStruct is built.

Overriding the division operators is used as a means to name the StrConstructs, while providing a user-friendly syntax for user (similar to Construct).