### PR TITLE
Add StrConst

### DIFF
--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -23,7 +23,9 @@ class ConstructBase:
     def _parse(self, string):
         raise NotImplementedError("Should be overridden by the child classes")
 
-    def build(self, value):
+    def build(self, value=None):
+        # Some StrConstruct class do not necessarily need a value for building. StrConst
+        # and StrDefault are sample examples.
         return self._build(value)
 
     def parse(self, string):

--- a/src/str_const.py
+++ b/src/str_const.py
@@ -1,0 +1,20 @@
+from construct_base import ConstructBase
+from str_construct_exceptions import StrConstructParseError
+
+class StrConst(ConstructBase):
+    def __init__(self, const, name=None):
+        self.name = name
+        self._const = const
+
+    def _build(self, value):
+        if value is not None and value != self._const:
+            raise ValueError("StrConst needs the same constant value or nothing to build")
+
+        return self._const
+
+    def _parse(self, string):
+        if string != self._const:
+            raise StrConstructParseError(
+                f"Received string ({string}) does not match the constant value ({self._const})"
+            )
+        return string

--- a/test/unit/test_str_const.py
+++ b/test/unit/test_str_const.py
@@ -1,0 +1,29 @@
+import sys
+import os
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
+
+from str_const import StrConst
+from str_construct_exceptions import StrConstructParseError
+
+class TestStrStruct:
+    def test_build_fails_with_value(self):
+        packet = StrConst("MyString")
+        with pytest.raises(ValueError):
+            packet.build(2)
+        packet.build("MyString")
+
+    def test_build(self):
+        packet = StrConst(">@")
+        assert packet.build() == ">@"
+
+    def test_parse(self):
+        packet = StrConst(">@")
+        assert packet.parse(">@") == ">@"
+
+    def test_parse_not_match_fails(self):
+        packet = StrConst(">@")
+        with pytest.raises(StrConstructParseError):
+            assert packet.parse("@") == ">@"

--- a/test/unit/test_str_struct.py
+++ b/test/unit/test_str_struct.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
 from str_int import StrInt
 from str_float import StrFloat
 from str_struct import StrStruct
+from str_const import StrConst
 
 class TestStrStruct:
     def test_field_type(self):
@@ -51,13 +52,9 @@ class TestStrStruct:
         output = packet.build({})
         assert output == ""
 
-
-    @pytest.mark.xfail(
-        reason="Needs StrConstruct objects that can build without values e.g. StrDefault"
-    )
     def test_build_with_nameless_fields(self):
         packet = StrStruct(
-            StrInt(""),
+            StrConst(">>"),
             "field2" / StrInt("02X"),
             separator=",",
         )
@@ -66,7 +63,7 @@ class TestStrStruct:
                 "field2": 15,
             }
         )
-        assert output == ""  # ?
+        assert output == ">>,0F"
 
     def test_parse_simple(self):
         packet = StrStruct(


### PR DESCRIPTION
StrConst is useful for applications where a constant string is present in all the messages and user does not want to provide their value in every call the build methods.