### PR TITLE
Add StrDefault

### DIFF
--- a/src/str_default.py
+++ b/src/str_default.py
@@ -1,0 +1,16 @@
+from construct_base import ConstructBase
+
+class StrDefault(ConstructBase):
+    def __init__(self, construct, default, name=None, format_processed=False):
+        self._subconstruct = construct
+        self._default = default
+        self.name = name
+
+    def _build(self, value):
+        if value is None:
+            return self._subconstruct.build(self._default)
+
+        return self._subconstruct.build(value)
+
+    def _parse(self, string):
+        return self._subconstruct.parse(string)

--- a/test/unit/test_str_const.py
+++ b/test/unit/test_str_const.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
 from str_const import StrConst
 from str_construct_exceptions import StrConstructParseError
 
-class TestStrStruct:
+class TestStrConst:
     def test_build_fails_with_value(self):
         packet = StrConst("MyString")
         with pytest.raises(ValueError):

--- a/test/unit/test_str_default.py
+++ b/test/unit/test_str_default.py
@@ -1,0 +1,19 @@
+import sys
+import os
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
+
+from str_int import StrInt
+from str_default import StrDefault
+
+class TestStrDefault:
+    def test_build_with_value(self):
+        assert StrDefault(StrInt("02X"), 17).build(2) == "02"
+
+    def test_build_without_value(self):
+        assert StrDefault(StrInt("02X"), 17).build() == "11"
+
+    def test_parse_with_value(self):
+        assert StrDefault(StrInt("02x"), 17).parse("10") == 16

--- a/test/unit/test_str_struct.py
+++ b/test/unit/test_str_struct.py
@@ -9,6 +9,7 @@ from str_int import StrInt
 from str_float import StrFloat
 from str_struct import StrStruct
 from str_const import StrConst
+from str_default import StrDefault
 from str_construct_exceptions import StrConstructParseError
 
 class TestStrStruct:
@@ -56,6 +57,7 @@ class TestStrStruct:
     def test_build_with_nameless_fields(self):
         packet = StrStruct(
             StrConst(">>"),
+            StrDefault(StrFloat("0.3f"), 2.345),
             "field2" / StrInt("02X"),
             separator=",",
         )
@@ -64,7 +66,7 @@ class TestStrStruct:
                 "field2": 15,
             }
         )
-        assert output == ">>,0F"
+        assert output == ">>,2.345,0F"
 
     def test_parse_simple(self):
         packet = StrStruct(


### PR DESCRIPTION
StrDefault, similar to Default in Construct, receives a construct object and a default value. When building without a value, the default value will be passed on the provided construct. Building with a value is exactly similar to building the underlying construct with that value.

The default value has no impact on parsing.