### PR TITLE
Simiplied the naming procedure

### DIFF
--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -1,15 +1,13 @@
 class ConstructBase:
-    def __init__(self, format_, name=None, format_processed=False):
-        if format_processed is False:
-            self._format = f"{{:{format_}}}"
-        else:
-            self._format = format_
-        self.name = name
+    def __init__(self, format_):
+        self._format = f"{{:{format_}}}"
+        self.name = None
 
     def _div(self, other):
         if not isinstance(other, str):
             raise TypeError("Division is support only for strings")
-        return self.__class__(self._format, other, format_processed=True)
+        self.name = other
+        return self
 
     def __truediv__(self, other):
         return self._div(other)

--- a/src/str_const.py
+++ b/src/str_const.py
@@ -2,8 +2,8 @@ from construct_base import ConstructBase
 from str_construct_exceptions import StrConstructParseError
 
 class StrConst(ConstructBase):
-    def __init__(self, const, name=None):
-        self.name = name
+    def __init__(self, const):
+        self.name = None
         self._const = const
 
     def _build(self, value):

--- a/src/str_default.py
+++ b/src/str_default.py
@@ -1,10 +1,10 @@
 from construct_base import ConstructBase
 
 class StrDefault(ConstructBase):
-    def __init__(self, construct, default, name=None, format_processed=False):
+    def __init__(self, construct, default):
         self._subconstruct = construct
         self._default = default
-        self.name = name
+        self.name = None
 
     def _build(self, value):
         if value is None:

--- a/src/str_int.py
+++ b/src/str_int.py
@@ -1,25 +1,17 @@
+
 from construct_base import ConstructBase
 from str_construct_exceptions import StrConstructParseError
 
 class StrInt(ConstructBase):
-    def __init__(self, format_, name=None, format_processed=False):
-        self.name = name
+    def __init__(self, format_):
+        self.name = None
+        self._format = f"{{:{format_}}}"
 
         if len(format_) == 0:
             raise ValueError(
                 "Invalid format. At least the integer representation should be "
                 "provided (e.g. 'd', 'x' etc.)"
             )
-
-        # TODO: This doesn't seem ideal anymore. I can add a new method (e.g. _get_named)
-        # that returns a named object and copies the whole rest of the object
-        if format_[0] != "{":  # Not constructed yet
-            self._format = f"{{:{format_}}}"
-        else:
-            self._format = format_
-            if format_[1] != ":":  # Just to confirm
-                raise ValueError("Format needs to be either in format of {{:<format>}} or <format>")
-            format_ = format_[2:-1]
 
         self._format_type = format_[-1]
         if self._format_type not in ["d", "x", "X"]:


### PR DESCRIPTION
We don't really need to instantiate new objects upon a division operator. We can simply name the current object and return it. The extra logic for instantiating a construct object off of another construct object has been removed.