### PR TITLE
StrStruct can parse even without a separator

### DIFF
--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -2,6 +2,7 @@ class ConstructBase:
     def __init__(self, format_):
         self._format = f"{{:{format_}}}"
         self.name = None
+        self._parse_left = None
 
     def _div(self, other):
         if not isinstance(other, str):
@@ -28,3 +29,10 @@ class ConstructBase:
 
     def parse(self, string):
         return self._parse(string)
+
+    def parse_left(self):
+        if self._parse_left is None:
+            raise RuntimeError("No parse has been requested or the last one failed")
+        output = self._parse_left
+        self._parse_left = None
+        return output

--- a/src/str_const.py
+++ b/src/str_const.py
@@ -13,8 +13,7 @@ class StrConst(ConstructBase):
         return self._const
 
     def _parse(self, string):
-        if string != self._const:
-            raise StrConstructParseError(
-                f"Received string ({string}) does not match the constant value ({self._const})"
-            )
-        return string
+        if not string.startswith(self._const):
+            raise StrConstructParseError(f"Expected '{self._const}' but found '{string}'")
+        self._parse_left = string[len(self._const) :]
+        return self._const

--- a/src/str_float.py
+++ b/src/str_float.py
@@ -14,10 +14,12 @@ class StrFloat(ConstructBase):
             raise ValueError(f"Format ({self._format_type}) not supported by StrFloat")
 
         break_down = format_[:-1].split(".")
-        if len(break_down) == 1:
-            self._format_length = 0
-        else:
+        try:
             self._format_length = int(break_down[1])
+        # ValueError happens if breakdown[1] is an empty string
+        # IndexError happens if there is not index 1 at all
+        except (ValueError, IndexError):
+            self._format_length = 0
 
     def _build(self, value):
         return f"{self._format}".format(value)
@@ -34,4 +36,5 @@ class StrFloat(ConstructBase):
                 f"Insufficient characters found. At least {self._format_length} "
                 "decimal numbers are needed"
             )
+        self._parse_left = string[(len(whole) + 1 + self._format_length):]
         return float(".".join([whole, decimal[:self._format_length]]))

--- a/src/str_int.py
+++ b/src/str_int.py
@@ -51,16 +51,21 @@ class StrInt(ConstructBase):
                     "character is needed"
                 )
             number = string[:self._format_length]
+            parse_left = string[self._format_length:]
         else:
             number = []
-            for char in string:
+            for index, char in enumerate(string):
                 if char in self._supported_chars:
                     number.append(char)
+                else:
+                    break
             number = "".join(number)
+            parse_left = string[index:]
 
         if number == "":
             raise StrConstructParseError("No numeric content collected from the input")
 
+        self._parse_left = parse_left
         if self._format_type == "d":
             return int(number) * multiplier
         if self._format_type == "x" or self._format_type == "X":

--- a/test/unit/test_str_default.py
+++ b/test/unit/test_str_default.py
@@ -6,14 +6,18 @@ import pytest
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../src"))
 
 from str_int import StrInt
+from str_float import StrFloat
 from str_default import StrDefault
 
 class TestStrDefault:
     def test_build_with_value(self):
         assert StrDefault(StrInt("02X"), 17).build(2) == "02"
+        assert StrDefault(StrFloat("0.3f"), 17.984).build(2) == "2.000"
 
     def test_build_without_value(self):
         assert StrDefault(StrInt("02X"), 17).build() == "11"
+        assert StrDefault(StrFloat("0.3f"), 17.984).build() == "17.984"
 
     def test_parse_with_value(self):
         assert StrDefault(StrInt("02x"), 17).parse("10") == 16
+        assert StrDefault(StrFloat(".3f"), 17.984).parse("11.123") == 11.123

--- a/test/unit/test_str_float.py
+++ b/test/unit/test_str_float.py
@@ -15,6 +15,7 @@ class TestStrFloat:
 
     def test_parse_no_decimal(self):
         assert StrFloat(".0f").parse("2") == 2
+        assert StrFloat(".f").parse("2.") == 2
         assert isinstance(StrFloat("f").parse("2"), float)
         assert StrFloat(".0f").build(2.123) == "2"
 


### PR DESCRIPTION
All the strConstruct objects now perform a greedy search if their format does not specify length. If it does, they consume only as many characters as specified in length. The greedy search continues as long the found characters form a parsable string. As soon as a non-parsable character is found (e.g. "," by a StrInt object), the parse algorithmm stops.

As such, they needed a new API to return the remaining string that their parse method did not consume. With that approach, StrStruct object can also work without separator characters.