### PR TITLE
Add StrSwitch

### DIFF
--- a/docs/src/api.rst
+++ b/docs/src/api.rst
@@ -6,7 +6,14 @@ API
    :undoc-members:
    :show-inheritance:
    :special-members: __init__
+
 .. autoclass:: strconstruct.StrFloat
+   :members: _build, _parse
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
+.. autoclass:: strconstruct.StrSwitch
    :members: _build, _parse
    :undoc-members:
    :show-inheritance:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,5 @@ from .str_int import StrInt
 from .str_float import StrFloat
 from .str_const import StrConst
 from .str_default import StrDefault
+from .str_switch import StrSwitch
 from .str_construct_exceptions import *

--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -1,3 +1,6 @@
+from .str_construct_exceptions import StrConstructBuildError
+
+
 class ConstructBase:
     def __init__(self, format_):
         self._format = f"{{:{format_}}}"
@@ -16,19 +19,19 @@ class ConstructBase:
     def __rtruediv__(self, other):
         return self._div(other)
 
-    def _build(self, value):
+    def _build(self, value, **kwargs):
         raise NotImplementedError("Should be overridden by the child classes")
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs):
         raise NotImplementedError("Should be overridden by the child classes")
 
-    def build(self, value=None):
+    def build(self, value=None, **kwargs):
         # Some StrConstruct class do not necessarily need a value for building. StrConst
         # and StrDefault are sample examples.
-        return self._build(value)
+        return self._build(value, **kwargs)
 
-    def parse(self, string):
-        return self._parse(string)
+    def parse(self, string, **kwargs):
+        return self._parse(string, **kwargs)
 
     def parse_left(self):
         if self._parse_left is None:

--- a/src/str_const.py
+++ b/src/str_const.py
@@ -1,18 +1,19 @@
 from .construct_base import ConstructBase
 from .str_construct_exceptions import StrConstructParseError
 
+
 class StrConst(ConstructBase):
     def __init__(self, const):
         self.name = None
         self._const = const
 
-    def _build(self, value):
+    def _build(self, value, **kwargs):
         if value is not None and value != self._const:
             raise ValueError("StrConst needs the same constant value or nothing to build")
 
         return self._const
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs):
         if not string.startswith(self._const):
             raise StrConstructParseError(f"Expected '{self._const}' but found '{string}'")
         self._parse_left = string[len(self._const) :]

--- a/src/str_default.py
+++ b/src/str_default.py
@@ -6,11 +6,13 @@ class StrDefault(ConstructBase):
         self._default = default
         self.name = None
 
-    def _build(self, value):
+    def _build(self, value, **kwargs):
+        # TODO: This should work with empty dict instead of None. See the following link
+        # https://construct.readthedocs.io/en/latest/misc.html#default
         if value is None:
             return self._subconstruct.build(self._default)
 
         return self._subconstruct.build(value)
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs):
         return self._subconstruct.parse(string)

--- a/src/str_float.py
+++ b/src/str_float.py
@@ -55,19 +55,29 @@ class StrFloat(ConstructBase):
         except (ValueError, IndexError):
             self._format_length = None
 
-    def _build(self, value):
+    def _build(self, value, **kwargs) -> str:
         """Backend method for building strings representing floating-point numbers
 
         Args:
             value: The value to be built
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Ignore by StrFloat.
+
+        Returns:
+            The built string
         """
         return f"{self._format}".format(value)
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs) -> float:
         """Backend method for parsing strings representing floating-point numbers
 
         Args:
             string: The input string
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Will be ignored by StrFloat
+
+        Returns:
+            The parsed content as a ``float`` object
         """
         break_down = string.split(".")
         if len(break_down) == 1:

--- a/src/str_int.py
+++ b/src/str_int.py
@@ -91,19 +91,29 @@ class StrInt(ConstructBase):
         except ValueError:
             self._format_length = None
 
-    def _build(self, value):
+    def _build(self, value, **kwargs) -> str:
         """Backend method for building numeric strings
 
         Args:
             value: The value to be built
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Ignore by StrInt.
+
+        Returns:
+            The built string
         """
         return f"{self._format}".format(value)
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs) -> int:
         """Backend method for parsing numeric strings
 
         Args:
             string: The input string
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Will be ignored by StrFloat
+
+        Returns:
+            The parsed content as an ``int`` object
         """
         if string[0] == "-":
             multiplier = -1

--- a/src/str_struct.py
+++ b/src/str_struct.py
@@ -24,7 +24,7 @@ class StrStruct(ConstructBase):
             raise TypeError("Division is support only for strings")
         return StrStruct(name=other, separator=self._separator, *self._fields)
 
-    def _build(self, values):
+    def _build(self, values, **kwargs):
         if not isinstance(values, dict):
             raise TypeError("The value for building an StrConstruct should be a dict")
 
@@ -35,18 +35,23 @@ class StrStruct(ConstructBase):
                 # build method of the corresponding object is expected to be able to build
                 # without a give value. Let's give it a try.
                 try:
-                    output = field.build()
+                    output = field.build(**kwargs)
                 except Exception as e:
                     raise StrConstructBuildError("Could not build the nameless field")
 
             else:
-                value = values[field.name]
-                output = field.build(value)
+                try:
+                    value = values[field.name]
+                except KeyError:
+                    # If the key-value pair is not provided, try to build it with no value
+                    output = field.build(**kwargs)
+                else:
+                    output = field.build(value, **kwargs)
             outputs.append(output)
 
         return self._separator.join(outputs)
 
-    def _parse(self, string):
+    def _parse(self, string, **kwargs):
         outputs = {}
         for index, field in enumerate(self._fields):
             output = field.parse(string)

--- a/src/str_switch.py
+++ b/src/str_switch.py
@@ -1,0 +1,178 @@
+import typing
+
+from .construct_base import ConstructBase
+from .str_construct_exceptions import StrConstructParseError, StrConstructBuildError
+
+
+class StrSwitch(ConstructBase):
+    """StrSwitch helps with running different build/parse paths depending on a set
+    of conditions, similar to switch statement in languages like C.
+        >>> from strconstruct import StrSwitch, StrInt, StrFloat
+        >>> d = StrSwitch(
+        ...     1,
+        ...     {
+        ...         1: StrFloat("0.3f"),
+        ...         2: StrInt("02d")
+        ...     }
+        ... )
+        >>> d.build(2)
+        '2.000'
+        >>> d = StrSwitch(
+        ...     2,
+        ...     {
+        ...         1: StrFloat("0.3f"),
+        ...         2: StrInt("02d")
+        ...     }
+        ... )
+        >>> d.build(2)
+        '02'
+
+    Of course the above example is not very useful by itself. It just attempts to show
+    how the first argument selects the build path. A more useful scenario, is to provide
+    a callable as the condition:
+
+        >>> from strconstruct import StrFloat, StrConst, StrDefault, StrStruct, StrInt
+        >>> d = StrSwitch(
+        ...     lambda this: this["n"],
+        ...     {
+        ...         1: StrFloat("0.1f"),
+        ...         2: StrConst("@"),
+        ...         3: StrDefault(StrInt("03X"), 17),
+        ...         4: StrStruct(
+        ...             "field1" / StrInt("d"),
+        ...             StrConst("-"),
+        ...             "field2" / StrFloat(".2f"),
+        ...         )
+        ...     },
+        ...     default=StrInt("d")
+        ... )
+        >>> d.build(2, n=1)
+        '2.0'
+        >>> d.build(n=2)
+        '@'
+        >>> d.build(n=3)
+        '011'
+        >>> d.build(16, n=3)
+        '010'
+        >>> d.build(14, n=103)
+        '14'
+        >>> d.build(
+        ...     {
+        ...         "field1": 13,
+        ...         "field2": 17.29,
+        ...     },
+        ...     n=4,
+        ... )
+        '13-17.29'
+
+    The callable should receive an argument, which will be set to the context when called.
+    (`Construct <https://construct.readthedocs.io/en/latest/index.html>`_ also provides
+    `context <https://construct.readthedocs.io/en/latest/meta.html#the-context>`_ and
+    `this <https://construct.readthedocs.io/en/latest/meta.html#using-this-expression>`_)
+
+    Parsing provides a similar functionality
+
+    >>> d = StrSwitch(
+    ...     lambda ctx: 1,
+    ...     {
+    ...         1: StrFloat("0.1f"),
+    ...         2: StrConst("@")
+    ...     }
+    ... )
+    >>> d.parse("2.0")
+    2.0
+    >>> d = StrSwitch(
+    ...     lambda ctx: 2,
+    ...     {
+    ...         1: StrFloat("0.1f"),
+    ...         2: StrConst("@")
+    ...     }
+    ... )
+    >>> d.parse("@")
+    '@'
+    """
+    def __init__(self, condition: typing.Any, cases: dict, default: ConstructBase = None):
+        """
+        Args:
+            condition: The condition for selecting cases. Can be a value or a callable. If
+                a callable, it should be able to receive an argument and return a value for
+                selecting a case (provided by ``cases``). The context will be given to the
+                callable.
+            cases: The cases from which one will be selected based on ``condition``. The
+                keys will be compared to ``condition`` (or its return value when callable).
+                The values should be strconstruct objects. The selected strconstruct object
+                will be used for building.
+            default: The default case for building - used when none of the cases is
+                a match.
+        """
+        # TODO: Add reference for "context in the above documentation"
+        self.name = None
+        self._condition = condition
+        self._cases = cases
+        self._default = default
+
+    def _build(self, value, **kwargs) -> str:
+        """Backend method for building numeric strings
+
+        If the provide ``condition`` is callable, this method will call it to get a value and
+        decide which build path should be take.
+
+        Args:
+            value: The value to be built
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Can be used for providing value to the condition
+
+                >>> d = StrSwitch(
+                ...     lambda this: this["n"],
+                ...     {
+                ...         1: StrFloat("0.1f"),
+                ...         2: StrInt("02d")
+                ...     }
+                ... )
+                >>> d.build(2, n=1)
+                '2.0'
+                >>> d.build(2, n=2)
+                '02'
+
+        Returns:
+            The built string
+
+        Raises:
+            StrConstructBuildError: If ``condition`` or its return value, when callable, does
+                not have a match in the provided cases and no default case is provided.
+        """
+        ctx = kwargs
+        condition = self._condition
+        if callable(condition):
+            condition = condition(ctx)
+        try:
+            subconstruct = self._cases[condition]
+        except KeyError:
+            if self._default is None:
+                raise StrConstructBuildError("No match found and default is not set")
+            subconstruct = self._default
+        return subconstruct.build(value, **kwargs)
+
+    def _parse(self, string, **kwargs):
+        """Backend method for parsing numeric strings
+
+        Args:
+            string: The input string
+            **kwargs: Other values that might be provided to the build method as additional
+                context. Can be used for providing value to the condition. See
+                :func:`~StrSwitch._build` for more info.
+
+        Returns:
+            The parsed content. The type depends on the selected case
+        """
+        ctx = kwargs
+        condition = self._condition
+        if callable(condition):
+            condition = condition(ctx)
+        try:
+            subconstruct = self._cases[condition]
+        except KeyError:
+            if self._default is None:
+                raise StrConstructParseError("No match found and default is not set")
+            subconstruct = self._default
+        return subconstruct.parse(string, **kwargs)

--- a/test/unit/test_str_float.py
+++ b/test/unit/test_str_float.py
@@ -3,15 +3,15 @@ import pytest
 from strconstruct import StrFloat, StrConstructParseError
 
 class TestStrFloat:
-#     def test_build_no_decimal(self):
-#         assert StrFloat(".0f").build(2) == "2"
-#         assert StrFloat(".0f").build(2.123) == "2"
+    def test_build_no_decimal(self):
+        assert StrFloat(".0f").build(2) == "2"
+        assert StrFloat(".0f").build(2.123) == "2"
 
     def test_parse_no_decimal_format(self):
-        # assert StrFloat(".0f").parse("2") == 2
-        # assert StrFloat(".f").parse("2.") == 2
+        assert StrFloat(".0f").parse("2") == 2
+        assert StrFloat(".f").parse("2.") == 2
         assert StrFloat(".f").parse(".2") == .2
-        # assert StrFloat(".1f").parse("1.2@3.4") == 1.2
+        assert StrFloat(".1f").parse("1.2@3.4") == 1.2
         assert isinstance(StrFloat("f").parse("2"), float)
         assert StrFloat(".0f").build(2.123) == "2"
 

--- a/test/unit/test_str_struct.py
+++ b/test/unit/test_str_struct.py
@@ -193,3 +193,15 @@ class TestStrStruct:
             }
         )
         assert output == "2,0F,3.10,00A"
+
+    def test_named_const_build_no_value(self):
+        packet = StrStruct(
+            "field1" / StrInt("d"),
+            "_hidden" / StrConst("-"),
+        )
+        output = packet.build(
+            {
+                "field1": 12
+            }
+        )
+        assert output == "12-"

--- a/test/unit/test_str_switch.py
+++ b/test/unit/test_str_switch.py
@@ -1,0 +1,184 @@
+import pytest
+
+from strconstruct import (
+    StrSwitch, StrFloat, StrConst, StrInt, StrDefault, StrStruct, StrConstructBuildError,
+    StrConstructParseError
+)
+
+
+class TestStrSwitch:
+    def test_build_constant_condition(self):
+        d = StrSwitch(
+            1,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.build(2) == "2.0"
+
+        d = StrSwitch(
+            2,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.build() == "@"
+
+        d = StrSwitch(
+            3,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            },
+            default=StrInt("d")
+        )
+        assert d.build(13) == "13"
+
+        d = StrSwitch(
+            3,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            },
+        )
+        with pytest.raises(StrConstructBuildError):
+            d.build()
+
+    def test_parse_constant_condition(self):
+        d = StrSwitch(
+            1,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.parse("2.0") == 2.0
+
+        d = StrSwitch(
+            2,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.parse("@") == "@"
+
+        d = StrSwitch(
+            3,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            },
+            default=StrInt("d")
+        )
+        assert d.parse("13") == 13
+
+        d = StrSwitch(
+            3,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            },
+        )
+        with pytest.raises(StrConstructParseError):
+            d.parse("")
+
+    def test_build_callable_condition(self):
+        d = StrSwitch(
+            lambda ctx: 1,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.build(2) == "2.0"
+
+        d = StrSwitch(
+            lambda ctx: 2,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.build() == "@"
+
+    def test_parse_callable_condition(self):
+        d = StrSwitch(
+            lambda ctx: 1,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.parse("2.0") == 2.
+
+        d = StrSwitch(
+            lambda ctx: 2,
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@")
+            }
+        )
+        assert d.parse("@") == "@"
+
+    def test_build_with_context(self):
+        """See the following link for more examples from Construct itself
+
+        https://construct.readthedocs.io/en/latest/misc.html?highlight=switch#switch
+        """
+        d = StrSwitch(
+            lambda this: this["n"],
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@"),
+                3: StrDefault(StrInt("03X"), 17),
+                4: StrStruct(
+                    "field1" / StrInt("d"),
+                    StrConst("-"),
+                    "field2" / StrFloat(".2f"),
+                )
+            },
+            default=StrInt("d")
+        )
+        assert d.build(2, n=1) == "2.0"
+        assert d.build(n=2) == "@"
+        assert d.build(n=3) == "011"
+        assert d.build(16, n=3) == "010"
+        assert d.build(14, n=103) == "14"
+
+        output = d.build(
+            {
+                "field1": 13,
+                "field2": 17.29,
+            },
+            n=4,
+        )
+        assert output == "13-17.29"
+
+    def test_parse_with_context(self):
+        d = StrSwitch(
+            lambda this: this["n"],
+            {
+                1: StrFloat("0.1f"),
+                2: StrConst("@"),
+                3: StrDefault(StrInt("03X"), 17),
+                4: StrStruct(
+                    "field1" / StrInt("d"),
+                    StrConst("-"),
+                    "field2" / StrFloat(".2f"),
+                )
+            },
+            default=StrInt("d")
+        )
+        assert d.parse("0.2", n=1) == 0.2
+        assert d.parse("@", n=2) == "@"
+        assert d.parse("011", n=3) == 17
+        assert d.parse("14", n=103) == 14
+
+        output = d.parse("78-198.23", n=4)
+        assert output == {
+            "field1": 78,
+            "field2": 198.23
+        }


### PR DESCRIPTION
StrSwitch is able to work with normal values as well as callables to determing the required build/parse path.

Also fixed a corner case in StrStruct. The named values need to be able to build, if they can, when no key-value pair is provided. Example str-construct classes for this scenario are StrDefault and StrConst.