### PR TITLE
Try ubuntu-20.04 for Read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-20.04
   tools:
     python: "3.6"
 


### PR DESCRIPTION
There seems to be an issue with installing the strConstruct python package and as a result the rendered document looks incomplete. The package is named UNKNOWN for some reason:
```
  ...
Building wheels for collected packages: UNKNOWN
  ...
Successfully built UNKNOWN
Installing collected packages: UNKNOWN
Successfully installed UNKNOWN-0.0.0
```

According to the folllowing link, the porblem may be related to Ubuntu 22.04.
https://github.com/pypa/setuptools/issues/3269#issuecomment-1254507377