### PR TITLE
Fix read-the-docs output

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.6"
+    python: "3.9"
 
 sphinx:
   builder: html


### PR DESCRIPTION
Despite previous changes, the installation of StrConstruct is still problematic in RTD's build.