### PR TITLE
Maintaine context while building and parsing

### DIFF
--- a/src/construct_base.py
+++ b/src/construct_base.py
@@ -30,7 +30,7 @@ class ConstructBase:
 
     def parse_left(self):
         if self._parse_left is None:
-            raise RuntimeError("No parse has been requested or the last one failed")
+            raise RuntimeError("No parse has been requested for the last one failed")
         output = self._parse_left
         self._parse_left = None
         return output

--- a/src/str_default.py
+++ b/src/str_default.py
@@ -1,5 +1,6 @@
 from .construct_base import ConstructBase
 
+
 class StrDefault(ConstructBase):
     def __init__(self, construct, default):
         self._subconstruct = construct
@@ -15,4 +16,6 @@ class StrDefault(ConstructBase):
         return self._subconstruct.build(value)
 
     def _parse(self, string, **kwargs):
-        return self._subconstruct.parse(string)
+        output = self._subconstruct.parse(string)
+        self._parse_left = self._subconstruct.parse_left()
+        return output

--- a/src/str_switch.py
+++ b/src/str_switch.py
@@ -154,19 +154,18 @@ class StrSwitch(ConstructBase):
             subconstruct = self._default
         return subconstruct.build(value, **kwargs)
 
-    def _parse(self, string, **kwargs):
+    def _parse(self, string, **ctx):
         """Backend method for parsing numeric strings
 
         Args:
             string: The input string
-            **kwargs: Other values that might be provided to the build method as additional
+            **ctx: Other values that might be provided to the build method as additional
                 context. Can be used for providing value to the condition. See
                 :func:`~StrSwitch._build` for more info.
 
         Returns:
             The parsed content. The type depends on the selected case
         """
-        ctx = kwargs
         condition = self._condition
         if callable(condition):
             condition = condition(ctx)
@@ -176,4 +175,6 @@ class StrSwitch(ConstructBase):
             if self._default is None:
                 raise StrConstructParseError("No match found and default is not set")
             subconstruct = self._default
-        return subconstruct.parse(string, **kwargs)
+        output = subconstruct.parse(string, **ctx)
+        self._parse_left = subconstruct.parse_left()
+        return output


### PR DESCRIPTION
In addition to getting arguments in the build and parse methods, each field, after being parsed or built, is now added to the context. This makes it possible to refer to the fields inside a StrStruct in other fields. One common example is StrSwitch, where we want to "switch" based on the value of another field.

The context is a dictionary. Every time a value is successfully built in StrStruct, it is added to context. Note that in this case the value is what is given to the build method (not its output).

Similarly, every time a field is parsed, it is added to the context. But there is a difference. This time the output of the parse function is added to the context and not its argument. This makes it possible to refer to other fields always by their names, regardless of whether it's building or parsing.